### PR TITLE
The template paths are missing the "v2"

### DIFF
--- a/languages/tribe-ext-event-progress-bar.pot
+++ b/languages/tribe-ext-event-progress-bar.pot
@@ -3,13 +3,13 @@ msgid ""
 msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 "Project-Id-Version: The Events Calendar Extension: Event Progress Bar\n"
-"POT-Creation-Date: 2020-11-06 10:55+0100\n"
+"POT-Creation-Date: 2021-12-03 23:58+0100\n"
 "PO-Revision-Date: 2020-11-02 10:10+0100\n"
-"Language-Team: Modern Tribe, Inc. <support@theeventscalendar.com>\n"
+"Language-Team: The Events Calendar <support@theeventscalendar.com>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.4.1\n"
+"X-Generator: Poedit 3.0\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-Flags-xgettext: --add-comments=translators:\n"
 "X-Poedit-WPHeader: tribe-ext-event-progress-bar.php\n"
@@ -26,46 +26,42 @@ msgctxt "Label before the progress bar when event is live."
 msgid "Live now"
 msgstr ""
 
-#: tribe-ext-event-progress-bar.php:117
-msgctxt "Label before the progress bar when event is over."
-msgid "Event"
-msgstr ""
-
-#: tribe-ext-event-progress-bar.php:127
+#: tribe-ext-event-progress-bar.php:121
 msgctxt "Label of the day after the progress bar when event is live."
 msgid "d"
 msgstr ""
 
 #. translators: %1$s: The remaining time with markup, %2$s: Closing </span>.
-#: tribe-ext-event-progress-bar.php:131
+#: tribe-ext-event-progress-bar.php:125
 #, php-format
 msgctxt "The remaining time of a live event, including HTML."
 msgid "%1$s left%2$s"
 msgstr ""
 
-#: tribe-ext-event-progress-bar.php:139
+#: tribe-ext-event-progress-bar.php:134
+#, php-format
 msgctxt "Label after the progress bar when the event is over."
-msgid "is over."
+msgid "%s is over."
 msgstr ""
 
-#: tribe-ext-event-progress-bar.php:161
+#: tribe-ext-event-progress-bar.php:158
 #, php-format
 msgid ""
 "%s requires PHP version %s or newer to work. Please contact your website "
 "host and inquire about updating PHP."
 msgstr ""
 
-#: tribe-ext-event-progress-bar.php:216
+#: tribe-ext-event-progress-bar.php:213
 msgctxt "name of view"
 msgid "Legacy Views"
 msgstr ""
 
-#: tribe-ext-event-progress-bar.php:218
+#: tribe-ext-event-progress-bar.php:215
 msgctxt "name of view"
 msgid "Updated (V2) Views"
 msgstr ""
 
-#: tribe-ext-event-progress-bar.php:230
+#: tribe-ext-event-progress-bar.php:227
 #, php-format
 msgid ""
 "%1$s requires the \"%2$s\" so this extension's code will not run until this "
@@ -83,14 +79,14 @@ msgstr ""
 
 #. Description of the plugin/theme
 msgid ""
-"This experimental extension adds a progress bar below the event description "
-"in list view and day view (V2)."
+"The extension adds a progress bar below the event description in list view "
+"and day view, when using the updated (v2) calendar design."
 msgstr ""
 
 #. Author of the plugin/theme
-msgid "Modern Tribe, Inc."
+msgid "The Events Calendar"
 msgstr ""
 
 #. Author URI of the plugin/theme
-msgid "http://m.tri.be/1971"
+msgid "https://evnt.is/1971"
 msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === The Events Calendar Extension: Event Progress Bar ===
-Contributors: ModernTribe
-Donate link: http://m.tri.be/29
+Contributors: theeventscalendar
+Donate link: https://evnt.is/29
 Tags: events, calendar
 Requires at least: 5.0
 Tested up to: 5.8.2

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: ModernTribe
 Donate link: http://m.tri.be/29
 Tags: events, calendar
 Requires at least: 5.0
-Tested up to: 5.5.3
+Tested up to: 5.8.2
 Requires PHP: 5.6
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPL version 3 or any later version
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -30,6 +30,10 @@ Please visit our [extension library](https://theeventscalendar.com/extensions/) 
 We're always interested in your feedback and our [Help Desk](https://support.theeventscalendar.com/) are the best place to flag any issues. Do note, however, that the degree of support we provide for extensions like this one tends to be very limited.
 
 == Changelog ==
+
+= [1.0.1] 2020-12-02 =
+
+* Make sure the extension uses the correct action hook names for v2.
 
 = [1.0.0] 2020-11-09 =
 

--- a/tribe-ext-event-progress-bar.php
+++ b/tribe-ext-event-progress-bar.php
@@ -70,8 +70,8 @@ if (
 				return;
 			}
 
-			add_action( 'tribe_template_after_include:events/list/event/description', [ $this, 'progressbar' ], 10, 3 );
-			add_action( 'tribe_template_after_include:events/day/event/description', [ $this, 'progressbar' ], 10, 3 );
+			add_action( 'tribe_template_after_include:events/v2/list/event/description', [ $this, 'progressbar' ], 10, 3 );
+			add_action( 'tribe_template_after_include:events/v2/day/event/description', [ $this, 'progressbar' ], 10, 3 );
 			add_action( 'wp_enqueue_scripts', [ $this, 'safely_add_scripts' ] );
 		}
 

--- a/tribe-ext-event-progress-bar.php
+++ b/tribe-ext-event-progress-bar.php
@@ -3,11 +3,11 @@
  * Plugin Name:       The Events Calendar Extension: Event Progress Bar
  * Plugin URI:        https://theeventscalendar.com/extensions/event-progress-bar/
  * GitHub Plugin URI: https://github.com/mt-support/tribe-ext-event-progress-bar
- * Description:       This experimental extension adds a progress bar below the event description in list view and day view (V2).
+ * Description:       The extension adds a progress bar below the event description in list view and day view, when using the updated (v2) calendar design.
  * Version:           1.0.1
  * Extension Class:   Tribe\Extensions\EventProgressBar\Main
- * Author:            Modern Tribe, Inc.
- * Author URI:        http://m.tri.be/1971
+ * Author:            The Events Calendar
+ * Author URI:        https://evnt.is/1971
  * License:           GPL version 3 or any later version
  * License URI:       https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain:       tribe-ext-event-progress-bar

--- a/tribe-ext-event-progress-bar.php
+++ b/tribe-ext-event-progress-bar.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://theeventscalendar.com/extensions/event-progress-bar/
  * GitHub Plugin URI: https://github.com/mt-support/tribe-ext-event-progress-bar
  * Description:       This experimental extension adds a progress bar below the event description in list view and day view (V2).
- * Version:           1.0.0
+ * Version:           1.0.1
  * Extension Class:   Tribe\Extensions\EventProgressBar\Main
  * Author:            Modern Tribe, Inc.
  * Author URI:        http://m.tri.be/1971


### PR DESCRIPTION
This fixes the paths for v2:

Day: https://d.pr/i/M69dVP
List: https://d.pr/i/NhWvIV